### PR TITLE
This seems to fix #32

### DIFF
--- a/app/src/main/java/com/udacity/stockhawk/data/PrefUtils.java
+++ b/app/src/main/java/com/udacity/stockhawk/data/PrefUtils.java
@@ -39,7 +39,7 @@ public final class PrefUtils {
 
     private static void editStockPref(Context context, String symbol, Boolean add) {
         String key = context.getString(R.string.pref_stocks_key);
-        Set<String> stocks = getStocks(context);
+        Set<String> stocks = new HashSet<>(getStocks(context));
 
         if (add) {
             stocks.add(symbol);


### PR DESCRIPTION
Symbol changes are not saving correctly to disk SharedPreferences.
[**This**](https://developer.android.com/reference/android/content/SharedPreferences.html#getStringSet(java.lang.String%2C%20java.util.Set%3Cjava.lang.String%3E)) could be the cause.

Read #32 for details.