### PR TITLE
fix: Fix app crash cause by limited Internet access 

### DIFF
--- a/app/src/main/java/com/udacity/stockhawk/sync/QuoteSyncJob.java
+++ b/app/src/main/java/com/udacity/stockhawk/sync/QuoteSyncJob.java
@@ -113,7 +113,7 @@ public final class QuoteSyncJob {
             Intent dataUpdatedIntent = new Intent(ACTION_DATA_UPDATED);
             context.sendBroadcast(dataUpdatedIntent);
 
-        } catch (IOException exception) {
+        } catch (IOException | StringIndexOutOfBoundsException exception) {
             Timber.e(exception, "Error fetching stock quotes");
         }
     }


### PR DESCRIPTION
The app is crashing upon starting if Wi-Fi is turned off and
Mobile Data is used but without having Internet access. The crash is
caused by an un-handled "StringIndexOutOfBoundsException" exception. This
exception is now handled in the try/catch clause of "getQuotes"
in the "QuoteSyncJob" class to avoid app crash on startup.

Resolves: #35