### PR TITLE
Updated YahooFinance API to fix redirect error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     compile 'com.jakewharton:butterknife:8.4.0'
     apt 'com.jakewharton:butterknife-compiler:8.4.0'
     compile 'com.google.guava:guava:20.0'
-    compile 'com.yahoofinance-api:YahooFinanceAPI:3.5.0'
+    compile 'com.yahoofinance-api:YahooFinanceAPI:3.6.1'
     compile 'com.jakewharton.timber:timber:4.4.0'
     compile 'net.sf.opencsv:opencsv:2.3'
     compile 'com.github.PhilJay:MPAndroidChart:v3.0.1'


### PR DESCRIPTION
YahooFinanceAPI was silently failing to download stock history. Bug was caused by an HTTP 301 redirect from http -> https and has been fixed in version 3.6.1. Updated build.gradle from 3.5.0 to 3.6.1. 